### PR TITLE
Support Scala 2.13.0-M5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,58 @@
+dist: xenial
 sudo: false
 language: scala
 
-scala:
-  - 2.12.8
-  - 2.11.12
+scala_version_211: &scala_version_211 2.11.12
+scala_version_212: &scala_version_212 2.12.8
+scala_version_213: &scala_version_213 2.13.0-M5
 
 jdk:
-  - openjdk11
+  - openjdk8
 
-before_install:
-  - export PATH=${PATH}:./vendor/bundle
+stages:
+  - name: test
+  - name: publish
+    if: (branch = master AND type = push)
 
-install:
-  - rvm use 2.6.0 --install --fuzzy
-  - gem update --system
-  - gem install sass
-  - gem install jekyll -v 3.2.1
+jobs:
+  include:
+    - &tests
+      env: TEST="test"
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION test
+        - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
+      scala: *scala_version_211
+    - <<: *tests
+      scala: *scala_version_212
+    - <<: *tests
+      scala: *scala_version_213
 
-script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
-  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
-  - sbt ++$TRAVIS_SCALA_VERSION docs/makeMicrosite
+    - env: TEST="docs"
+      before_install:
+        - export PATH=${PATH}:./vendor/bundle
+      install:
+        - rvm use 2.6.0 --install --fuzzy
+        - gem update --system
+        - gem install sass
+        - gem install jekyll -v 3.2.1
+      script: sbt ++$TRAVIS_SCALA_VERSION docs/makeMicrosite
+      scala: *scala_version_212
 
-after_success:
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/keypool" && sbt ++$TRAVIS_SCALA_VERSION publish
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/keypool" && test $TRAVIS_SCALA_VERSION == "2.12.8" && sbt docs/publishMicrosite
+    - &publish
+      stage: publish
+      env: TEST="publish"
+      scala: *scala_version_211
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION publish
+    - <<: *publish
+      scala: *scala_version_212
+    - <<: *publish
+      scala: *scala_version_213
+      
+    - env: TEST="publish docs"
+      scala: *scala_version_212
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION docs/publishMicrosite
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 lazy val `keypool` = project.in(file("."))
   .settings(commonSettings, releaseSettings, skipOnPublishSettings)
-  .aggregate(core, docs)
+  .settings(crossScalaVersions := Nil)
+  .aggregate(core)
 
 lazy val core = project.in(file("core"))
   .settings(commonSettings, releaseSettings, mimaSettings)
@@ -25,15 +26,15 @@ val catsEffectV = "1.3.0"
 
 val specs2V = "4.5.1"
 
-val kindProjectorV = "0.9.10"
-val betterMonadicForV = "0.3.0"
+val kindProjectorV = "0.9.9"
+val betterMonadicForV = "0.3.0-M4"
 
 // General Settings
 lazy val commonSettings = Seq(
   organization := "io.chrisdavenport",
 
   scalaVersion := "2.12.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-M5"),
   scalacOptions += "-Yrangepos",
 
   scalacOptions in (Compile, doc) ++= Seq(
@@ -176,6 +177,7 @@ lazy val mimaSettings = {
 lazy val micrositeSettings = {
   import microsites._
   Seq(
+    crossScalaVersions := List(scalaVersion.value),
     micrositeName := "keypool",
     micrositeDescription := "A Keyed Pool for Scala",
     micrositeAuthor := "Christopher Davenport",

--- a/build.sbt
+++ b/build.sbt
@@ -162,6 +162,7 @@ lazy val mimaSettings = {
     mimaFailOnProblem := mimaVersions(version.value).toList.headOption.isDefined,
     mimaPreviousArtifacts := (mimaVersions(version.value) ++ extraVersions)
       .filterNot(excludedVersions.contains(_))
+      .filterNot(Function.const(scalaVersion.value == "2.13.0-M5"))
       .map{v => 
         val moduleN = moduleName.value + "_" + scalaBinaryVersion.value.toString
         organization.value % moduleN % v

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.6")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.5")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")


### PR DESCRIPTION
This is necessary for potential adoption into http4s-0.20.  More complicated than expected because github4s is unavailable for 2.13.

A release on 2.13.0-RC1 is more desirable, but brings cats{-effect}-2 into the fold.